### PR TITLE
Added: Bounced email store or not modification filter

### DIFF
--- a/src/hooks/filters/_other_filters.md
+++ b/src/hooks/filters/_other_filters.md
@@ -153,3 +153,19 @@ add_filter('fluent_crm/edd_purchase_sidebar_html', function($sidebarHtml, $subsc
 }, 20, 3);
 ```
 </explain-block>
+
+<explain-block title="fluent_crm/bounced_email_store">
+This filter allows you to customize whether a bounced email should be stored in the system or not.
+
+**Parameters**
+- `$store` boolean - Default true
+
+**Usage:**
+```php
+/*
+* Prevent storing bounced emails in the system
+*/
+add_filter('fluent_crm/bounced_email_store', function($store) {
+    return false; // Prevent storing bounced emails
+}, 20, 3);
+```


### PR DESCRIPTION
When a user manages multiple sites and uses the same email service provider across those sites—along with configured bounce handling—bounced emails from one site may be recorded on other sites, potentially creating unintended contacts. To prevent this, we've introduced a filter that allows users to disable this default behavior. 
```php
/*
* Prevent storing bounced emails in the system
*/
add_filter('fluent_crm/bounced_email_store', function($store) {
    return false; // Prevent storing bounced emails
}, 20, 3);
```