### PR TITLE
Added: Add documentation for woo_dynamic_coupon_created hook

### DIFF
--- a/src/hooks/actions/_others_important_hooks.md
+++ b/src/hooks/actions/_others_important_hooks.md
@@ -1,0 +1,22 @@
+</explain-block>
+
+<explain-block title="fluent_crm/woo_dynamic_coupon_created">
+This action runs when a dynamically created coupon has been applied. This hook
+provides access to the created coupon object and related data, allowing for the
+programmatic addition of required metadata fields.
+
+
+
+**Parameters**
+- `$createdCoupon` - WC_Coupon object
+- `$funnelMetric` - Funnel Metric Model
+- `$subscriber` - Subscriber Model
+- `$couponData` - Array of coupon data
+
+**Usage:**
+```php 
+add_action('fluent_crm/woo_dynamic_coupon_created', function($createdCoupon, $funnelMetric, $subscriber, $couponData) {
+   // Do you staffs here
+});
+```
+</explain-block>

--- a/src/hooks/actions/index.md
+++ b/src/hooks/actions/index.md
@@ -184,3 +184,7 @@ add_action('fluent_crm/contact_updated_by_fluentform', function($subscriber, $en
 }, 10, 4);
 ```
 :::
+
+### Other Important Actions
+<hr />
+!!!include(./src/hooks/actions/_others_important_hooks.md)!!!


### PR DESCRIPTION
Introduced a new markdown file detailing the 'fluent_crm/woo_dynamic_coupon_created' action hook, including its parameters and usage example. Updated the actions index to include a reference to this new documentation under 'Other Important Actions'.
**screenshot**
<img width="967" alt="Screenshot 2025-07-10 at 11 59 29 AM" src="https://github.com/user-attachments/assets/f150d47a-211b-4757-b5b0-5a152a9ddaa3" />
