### PR TITLE
Add Email Patterns REST API docs

### DIFF
--- a/src/.vitepress/sidebars/rest-api.js
+++ b/src/.vitepress/sidebars/rest-api.js
@@ -150,6 +150,23 @@ export default [
         ]
     },
     {
+        text: 'Email Patterns',
+        collapsed: true,
+        items: [
+            { text: 'List Email Patterns <badge type="tip">GET</badge>', link: '/rest-api/operations/email-patterns/list-email-patterns' },
+            { text: 'List Patterns (WP Format) <badge type="tip">GET</badge>', link: '/rest-api/operations/email-patterns/list-email-patterns-wp-format' },
+            { text: 'List Categories <badge type="tip">GET</badge>', link: '/rest-api/operations/email-patterns/list-email-pattern-categories' },
+            { text: 'Create Category <badge type="warning">POST</badge>', link: '/rest-api/operations/email-patterns/create-email-pattern-category' },
+            { text: 'Delete Category <badge type="danger">DELETE</badge>', link: '/rest-api/operations/email-patterns/delete-email-pattern-category' },
+            { text: 'Create Email Pattern <badge type="warning">POST</badge>', link: '/rest-api/operations/email-patterns/create-email-pattern' },
+            { text: 'Create Pattern (WP Format) <badge type="warning">POST</badge>', link: '/rest-api/operations/email-patterns/create-email-pattern-wp-format' },
+            { text: 'Get Email Pattern <badge type="tip">GET</badge>', link: '/rest-api/operations/email-patterns/get-email-pattern' },
+            { text: 'Update Email Pattern <badge type="info">PUT</badge>', link: '/rest-api/operations/email-patterns/update-email-pattern' },
+            { text: 'Delete Email Pattern <badge type="danger">DELETE</badge>', link: '/rest-api/operations/email-patterns/delete-email-pattern' },
+            { text: 'Bulk Action <badge type="warning">POST</badge>', link: '/rest-api/operations/email-patterns/bulk-action-email-patterns' },
+        ]
+    },
+    {
         text: 'Funnels (Automations)',
         collapsed: true,
         items: [

--- a/src/public/openapi/email-patterns/bulk-action-email-patterns.json
+++ b/src/public/openapi/email-patterns/bulk-action-email-patterns.json
@@ -1,0 +1,178 @@
+{
+  "openapi": "3.0.4",
+  "info": {
+    "title": "FluentCRM API",
+    "description": "Complete REST API documentation for FluentCRM — a self-hosted email marketing and CRM plugin for WordPress.",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://{website}/wp-json/fluent-crm/v2",
+      "description": "Your WordPress website",
+      "variables": {
+        "website": {
+          "default": "YourWebsite.com",
+          "description": "Your WordPress website domain (without https://)"
+        }
+      }
+    }
+  ],
+  "security": [
+    {
+      "ApplicationPasswords": []
+    }
+  ],
+  "paths": {
+    "/email-patterns/do-bulk-action": {
+      "post": {
+        "operationId": "bulkActionEmailPatterns",
+        "summary": "POST Bulk Action Email Patterns",
+        "description": "Perform a bulk action on email patterns. Currently the only supported action is `delete_patterns`.",
+        "tags": [
+          "Email Patterns"
+        ],
+        "security": [
+          {
+            "ApplicationPasswords": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "action_name"
+                ],
+                "properties": {
+                  "action_name": {
+                    "type": "string",
+                    "enum": [
+                      "delete_patterns"
+                    ],
+                    "description": "The bulk action to perform."
+                  },
+                  "pattern_ids": {
+                    "type": "array",
+                    "description": "Array of email pattern IDs to delete when `select_all` is not truthy.",
+                    "items": {
+                      "type": "integer"
+                    }
+                  },
+                  "select_all": {
+                    "type": "boolean",
+                    "description": "If true, deletes all patterns matching the optional `search` filter instead of only the provided `pattern_ids`."
+                  },
+                  "search": {
+                    "type": "string",
+                    "description": "Optional search term used only with `select_all=true`."
+                  }
+                }
+              },
+              "examples": {
+                "deleteSelected": {
+                  "summary": "Delete selected patterns",
+                  "value": {
+                    "action_name": "delete_patterns",
+                    "pattern_ids": [
+                      12,
+                      14,
+                      18
+                    ]
+                  }
+                },
+                "deleteAllMatching": {
+                  "summary": "Delete all matching patterns",
+                  "value": {
+                    "action_name": "delete_patterns",
+                    "select_all": true,
+                    "search": "welcome"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Bulk action completed successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "message": "3 pattern(s) deleted successfully"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid action or no patterns selected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "invalidAction": {
+                    "summary": "Invalid action",
+                    "value": {
+                      "message": "Invalid action"
+                    }
+                  },
+                  "noSelection": {
+                    "summary": "No patterns selected",
+                    "value": {
+                      "message": "No patterns selected"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Human-readable error message"
+          },
+          "code": {
+            "type": "string",
+            "description": "Error code"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "integer",
+                "description": "HTTP status code"
+              }
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "ApplicationPasswords": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Authorization",
+        "description": "WordPress Application Passwords — use Basic auth with your WordPress username and an application password in the format: username:application_password"
+      }
+    }
+  }
+}

--- a/src/public/openapi/email-patterns/create-email-pattern-category.json
+++ b/src/public/openapi/email-patterns/create-email-pattern-category.json
@@ -1,0 +1,155 @@
+{
+  "openapi": "3.0.4",
+  "info": {
+    "title": "FluentCRM API",
+    "description": "Complete REST API documentation for FluentCRM — a self-hosted email marketing and CRM plugin for WordPress.",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://{website}/wp-json/fluent-crm/v2",
+      "description": "Your WordPress website",
+      "variables": {
+        "website": {
+          "default": "YourWebsite.com",
+          "description": "Your WordPress website domain (without https://)"
+        }
+      }
+    }
+  ],
+  "security": [
+    {
+      "ApplicationPasswords": []
+    }
+  ],
+  "paths": {
+    "/email-patterns/categories": {
+      "post": {
+        "operationId": "createEmailPatternCategory",
+        "summary": "POST Create Email Pattern Category",
+        "description": "Create an email pattern category. If a category with the same slug already exists, the existing category is returned instead of creating a duplicate.",
+        "tags": [
+          "Email Patterns"
+        ],
+        "security": [
+          {
+            "ApplicationPasswords": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Category name."
+                  }
+                }
+              },
+              "example": {
+                "name": "Onboarding"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Category created successfully or existing matching category returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmailPatternCategory"
+                },
+                "example": {
+                  "id": 3,
+                  "count": 0,
+                  "name": "Onboarding",
+                  "slug": "onboarding",
+                  "parent": 0
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Category name is missing.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "message": "Category name is required"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Human-readable error message"
+          },
+          "code": {
+            "type": "string",
+            "description": "Error code"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "integer",
+                "description": "HTTP status code"
+              }
+            }
+          }
+        }
+      },
+      "EmailPatternCategory": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Category ID."
+          },
+          "count": {
+            "type": "integer",
+            "description": "Pattern count placeholder. Currently always `0` in this response."
+          },
+          "name": {
+            "type": "string",
+            "description": "Category display name."
+          },
+          "slug": {
+            "type": "string",
+            "description": "Sanitized category slug."
+          },
+          "parent": {
+            "type": "integer",
+            "description": "Parent category ID. Currently always `0`."
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "ApplicationPasswords": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Authorization",
+        "description": "WordPress Application Passwords — use Basic auth with your WordPress username and an application password in the format: username:application_password"
+      }
+    }
+  }
+}

--- a/src/public/openapi/email-patterns/create-email-pattern-wp-format.json
+++ b/src/public/openapi/email-patterns/create-email-pattern-wp-format.json
@@ -1,0 +1,277 @@
+{
+  "openapi": "3.0.4",
+  "info": {
+    "title": "FluentCRM API",
+    "description": "Complete REST API documentation for FluentCRM — a self-hosted email marketing and CRM plugin for WordPress.",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://{website}/wp-json/fluent-crm/v2",
+      "description": "Your WordPress website",
+      "variables": {
+        "website": {
+          "default": "YourWebsite.com",
+          "description": "Your WordPress website domain (without https://)"
+        }
+      }
+    }
+  ],
+  "security": [
+    {
+      "ApplicationPasswords": []
+    }
+  ],
+  "paths": {
+    "/email-patterns/wp-format": {
+      "post": {
+        "operationId": "createEmailPatternWpFormat",
+        "summary": "POST Create Email Pattern (WP Format)",
+        "description": "Create a reusable email pattern using the WordPress `wp_block`-style payload used by the FluentCRM editor middleware. If no title is provided, FluentCRM creates the pattern as `Untitled Pattern`. If both title and content are empty, the request is rejected.",
+        "tags": [
+          "Email Patterns"
+        ],
+        "security": [
+          {
+            "ApplicationPasswords": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "raw": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    ],
+                    "description": "Pattern title. Supports plain string or editor-style `{ raw }` object."
+                  },
+                  "content": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "raw": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    ],
+                    "description": "Pattern content. Supports plain string or editor-style `{ raw }` object."
+                  },
+                  "meta": {
+                    "type": "object",
+                    "description": "WordPress editor metadata.",
+                    "properties": {
+                      "wp_pattern_sync_status": {
+                        "type": "string",
+                        "description": "Pattern sync status saved with the pattern."
+                      }
+                    }
+                  },
+                  "wp_pattern_category": {
+                    "type": "array",
+                    "description": "WordPress-style category IDs that are resolved back to a category name.",
+                    "items": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "example": {
+                "title": {
+                  "raw": "Welcome Pattern"
+                },
+                "content": {
+                  "raw": "<!-- wp:paragraph --><p>Welcome to our newsletter.</p><!-- /wp:paragraph -->"
+                },
+                "meta": {
+                  "wp_pattern_sync_status": "unsynced"
+                },
+                "wp_pattern_category": [
+                  3
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Email pattern created successfully in WordPress block format.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WpBlockEmailPattern"
+                },
+                "example": {
+                  "id": 13,
+                  "date": "2026-04-28 16:20:00",
+                  "date_gmt": "2026-04-28 16:20:00",
+                  "modified": "2026-04-28 16:20:00",
+                  "modified_gmt": "2026-04-28 16:20:00",
+                  "slug": "fluentcrm/welcome-pattern-13",
+                  "status": "publish",
+                  "type": "wp_block",
+                  "link": "",
+                  "title": {
+                    "raw": "Welcome Pattern"
+                  },
+                  "content": {
+                    "raw": "<!-- wp:paragraph --><p>Welcome to our newsletter.</p><!-- /wp:paragraph -->",
+                    "protected": false
+                  },
+                  "meta": {},
+                  "wp_pattern_sync_status": "unsynced",
+                  "wp_pattern_category": [
+                    3
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Both title and content were empty.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "message": "Title or content is required"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Human-readable error message"
+          },
+          "code": {
+            "type": "string",
+            "description": "Error code"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "integer",
+                "description": "HTTP status code"
+              }
+            }
+          }
+        }
+      },
+      "WpBlockEmailPattern": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Pattern ID."
+          },
+          "date": {
+            "type": "string",
+            "description": "Creation timestamp."
+          },
+          "date_gmt": {
+            "type": "string",
+            "description": "Creation timestamp in GMT."
+          },
+          "modified": {
+            "type": "string",
+            "description": "Last modification timestamp."
+          },
+          "modified_gmt": {
+            "type": "string",
+            "description": "Last modification timestamp in GMT."
+          },
+          "slug": {
+            "type": "string",
+            "description": "Pattern slug."
+          },
+          "status": {
+            "type": "string",
+            "description": "Always `publish` for this response shape."
+          },
+          "type": {
+            "type": "string",
+            "description": "Always `wp_block`."
+          },
+          "link": {
+            "type": "string",
+            "description": "Pattern link. Currently empty."
+          },
+          "title": {
+            "type": "object",
+            "properties": {
+              "raw": {
+                "type": "string",
+                "description": "Raw pattern title."
+              }
+            }
+          },
+          "content": {
+            "type": "object",
+            "properties": {
+              "raw": {
+                "type": "string",
+                "description": "Raw block content."
+              },
+              "protected": {
+                "type": "boolean",
+                "description": "Whether the content is protected."
+              }
+            }
+          },
+          "meta": {
+            "type": "object",
+            "description": "WordPress block metadata object."
+          },
+          "wp_pattern_sync_status": {
+            "type": "string",
+            "description": "Pattern sync status."
+          },
+          "wp_pattern_category": {
+            "type": "array",
+            "description": "Resolved WordPress-style category IDs.",
+            "items": {
+              "type": "integer"
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "ApplicationPasswords": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Authorization",
+        "description": "WordPress Application Passwords — use Basic auth with your WordPress username and an application password in the format: username:application_password"
+      }
+    }
+  }
+}

--- a/src/public/openapi/email-patterns/create-email-pattern.json
+++ b/src/public/openapi/email-patterns/create-email-pattern.json
@@ -1,0 +1,231 @@
+{
+  "openapi": "3.0.4",
+  "info": {
+    "title": "FluentCRM API",
+    "description": "Complete REST API documentation for FluentCRM — a self-hosted email marketing and CRM plugin for WordPress.",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://{website}/wp-json/fluent-crm/v2",
+      "description": "Your WordPress website",
+      "variables": {
+        "website": {
+          "default": "YourWebsite.com",
+          "description": "Your WordPress website domain (without https://)"
+        }
+      }
+    }
+  ],
+  "security": [
+    {
+      "ApplicationPasswords": []
+    }
+  ],
+  "paths": {
+    "/email-patterns": {
+      "post": {
+        "operationId": "createEmailPattern",
+        "summary": "POST Create Email Pattern",
+        "description": "Create a reusable email pattern in FluentCRM. The title and content fields are required. The pattern is stored under the current user and receives an auto-generated `fluentcrm/...` slug.",
+        "tags": [
+          "Email Patterns"
+        ],
+        "security": [
+          {
+            "ApplicationPasswords": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "title",
+                  "content"
+                ],
+                "properties": {
+                  "title": {
+                    "type": "string",
+                    "description": "Pattern title."
+                  },
+                  "content": {
+                    "type": "string",
+                    "description": "Pattern HTML or block markup content."
+                  },
+                  "category": {
+                    "type": "string",
+                    "description": "Optional category name."
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "Optional pattern description."
+                  },
+                  "sync_status": {
+                    "type": "string",
+                    "description": "Optional sync status value.",
+                    "default": "unsynced"
+                  }
+                }
+              },
+              "example": {
+                "title": "Welcome Pattern",
+                "content": "<!-- wp:paragraph --><p>Welcome to our newsletter.</p><!-- /wp:paragraph -->",
+                "category": "Onboarding",
+                "description": "Reusable onboarding email block.",
+                "sync_status": "unsynced"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Email pattern created successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "pattern": {
+                      "$ref": "#/components/schemas/EmailPattern"
+                    }
+                  }
+                },
+                "example": {
+                  "message": "Pattern saved successfully",
+                  "pattern": {
+                    "id": 13,
+                    "slug": "fluentcrm/welcome-pattern-13",
+                    "title": "Welcome Pattern",
+                    "content": "<!-- wp:paragraph --><p>Welcome to our newsletter.</p><!-- /wp:paragraph -->",
+                    "category": "Onboarding",
+                    "description": "Reusable onboarding email block.",
+                    "sync_status": "unsynced",
+                    "created_at": "2026-04-28 15:20:00",
+                    "updated_at": "2026-04-28 15:20:00"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation error. Returned when required fields are missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "message": "Unprocessable Entity!",
+                  "errors": {
+                    "title": [
+                      "The title field is required."
+                    ],
+                    "content": [
+                      "The content field is required."
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Human-readable error message"
+          },
+          "code": {
+            "type": "string",
+            "description": "Error code"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "integer",
+                "description": "HTTP status code"
+              }
+            }
+          }
+        }
+      },
+      "EmailPattern": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Pattern ID."
+          },
+          "slug": {
+            "type": "string",
+            "description": "Generated pattern slug."
+          },
+          "title": {
+            "type": "string",
+            "description": "Pattern title."
+          },
+          "content": {
+            "type": "string",
+            "description": "Pattern content HTML or block markup."
+          },
+          "category": {
+            "type": "string",
+            "description": "Assigned category name."
+          },
+          "description": {
+            "type": "string",
+            "description": "Pattern description."
+          },
+          "sync_status": {
+            "type": "string",
+            "description": "Pattern sync status.",
+            "default": "unsynced"
+          },
+          "created_at": {
+            "type": "string",
+            "description": "Pattern creation timestamp."
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "Pattern update timestamp."
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "ApplicationPasswords": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Authorization",
+        "description": "WordPress Application Passwords — use Basic auth with your WordPress username and an application password in the format: username:application_password"
+      }
+    }
+  }
+}

--- a/src/public/openapi/email-patterns/delete-email-pattern-category.json
+++ b/src/public/openapi/email-patterns/delete-email-pattern-category.json
@@ -1,0 +1,120 @@
+{
+  "openapi": "3.0.4",
+  "info": {
+    "title": "FluentCRM API",
+    "description": "Complete REST API documentation for FluentCRM — a self-hosted email marketing and CRM plugin for WordPress.",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://{website}/wp-json/fluent-crm/v2",
+      "description": "Your WordPress website",
+      "variables": {
+        "website": {
+          "default": "YourWebsite.com",
+          "description": "Your WordPress website domain (without https://)"
+        }
+      }
+    }
+  ],
+  "security": [
+    {
+      "ApplicationPasswords": []
+    }
+  ],
+  "paths": {
+    "/email-patterns/categories/{id}": {
+      "delete": {
+        "operationId": "deleteEmailPatternCategory",
+        "summary": "DELETE Delete Email Pattern Category",
+        "description": "Delete an email pattern category by its ID.",
+        "tags": [
+          "Email Patterns"
+        ],
+        "security": [
+          {
+            "ApplicationPasswords": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The email pattern category ID.",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Category deleted successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "message": "Category deleted successfully"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Category not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "message": "No query results for model"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Human-readable error message"
+          },
+          "code": {
+            "type": "string",
+            "description": "Error code"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "integer",
+                "description": "HTTP status code"
+              }
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "ApplicationPasswords": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Authorization",
+        "description": "WordPress Application Passwords — use Basic auth with your WordPress username and an application password in the format: username:application_password"
+      }
+    }
+  }
+}

--- a/src/public/openapi/email-patterns/delete-email-pattern.json
+++ b/src/public/openapi/email-patterns/delete-email-pattern.json
@@ -1,0 +1,120 @@
+{
+  "openapi": "3.0.4",
+  "info": {
+    "title": "FluentCRM API",
+    "description": "Complete REST API documentation for FluentCRM — a self-hosted email marketing and CRM plugin for WordPress.",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://{website}/wp-json/fluent-crm/v2",
+      "description": "Your WordPress website",
+      "variables": {
+        "website": {
+          "default": "YourWebsite.com",
+          "description": "Your WordPress website domain (without https://)"
+        }
+      }
+    }
+  ],
+  "security": [
+    {
+      "ApplicationPasswords": []
+    }
+  ],
+  "paths": {
+    "/email-patterns/{id}": {
+      "delete": {
+        "operationId": "deleteEmailPattern",
+        "summary": "DELETE Delete Email Pattern",
+        "description": "Delete a reusable email pattern by its ID.",
+        "tags": [
+          "Email Patterns"
+        ],
+        "security": [
+          {
+            "ApplicationPasswords": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The email pattern ID.",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Email pattern deleted successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "message": "Pattern deleted successfully"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Email pattern not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "message": "No query results for model"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Human-readable error message"
+          },
+          "code": {
+            "type": "string",
+            "description": "Error code"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "integer",
+                "description": "HTTP status code"
+              }
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "ApplicationPasswords": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Authorization",
+        "description": "WordPress Application Passwords — use Basic auth with your WordPress username and an application password in the format: username:application_password"
+      }
+    }
+  }
+}

--- a/src/public/openapi/email-patterns/get-email-pattern.json
+++ b/src/public/openapi/email-patterns/get-email-pattern.json
@@ -1,0 +1,172 @@
+{
+  "openapi": "3.0.4",
+  "info": {
+    "title": "FluentCRM API",
+    "description": "Complete REST API documentation for FluentCRM — a self-hosted email marketing and CRM plugin for WordPress.",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://{website}/wp-json/fluent-crm/v2",
+      "description": "Your WordPress website",
+      "variables": {
+        "website": {
+          "default": "YourWebsite.com",
+          "description": "Your WordPress website domain (without https://)"
+        }
+      }
+    }
+  ],
+  "security": [
+    {
+      "ApplicationPasswords": []
+    }
+  ],
+  "paths": {
+    "/email-patterns/{id}": {
+      "get": {
+        "operationId": "getEmailPattern",
+        "summary": "GET Get Email Pattern",
+        "description": "Retrieve a single reusable email pattern by its ID.",
+        "tags": [
+          "Email Patterns"
+        ],
+        "security": [
+          {
+            "ApplicationPasswords": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The email pattern ID.",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Email pattern retrieved successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "pattern": {
+                      "$ref": "#/components/schemas/EmailPattern"
+                    }
+                  }
+                },
+                "example": {
+                  "pattern": {
+                    "id": 12,
+                    "slug": "fluentcrm/welcome-pattern-12",
+                    "title": "Welcome Pattern",
+                    "content": "<!-- wp:paragraph --><p>Welcome to our newsletter.</p><!-- /wp:paragraph -->",
+                    "category": "Onboarding",
+                    "description": "Reusable onboarding email block.",
+                    "sync_status": "unsynced",
+                    "created_at": "2026-04-20 09:15:00",
+                    "updated_at": "2026-04-21 11:30:00"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Email pattern not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "message": "No query results for model"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Human-readable error message"
+          },
+          "code": {
+            "type": "string",
+            "description": "Error code"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "integer",
+                "description": "HTTP status code"
+              }
+            }
+          }
+        }
+      },
+      "EmailPattern": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Pattern ID."
+          },
+          "slug": {
+            "type": "string",
+            "description": "Generated pattern slug."
+          },
+          "title": {
+            "type": "string",
+            "description": "Pattern title."
+          },
+          "content": {
+            "type": "string",
+            "description": "Pattern content HTML or block markup."
+          },
+          "category": {
+            "type": "string",
+            "description": "Assigned category name."
+          },
+          "description": {
+            "type": "string",
+            "description": "Pattern description."
+          },
+          "sync_status": {
+            "type": "string",
+            "description": "Pattern sync status.",
+            "default": "unsynced"
+          },
+          "created_at": {
+            "type": "string",
+            "description": "Pattern creation timestamp."
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "Pattern update timestamp."
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "ApplicationPasswords": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Authorization",
+        "description": "WordPress Application Passwords — use Basic auth with your WordPress username and an application password in the format: username:application_password"
+      }
+    }
+  }
+}

--- a/src/public/openapi/email-patterns/list-email-pattern-categories.json
+++ b/src/public/openapi/email-patterns/list-email-pattern-categories.json
@@ -1,0 +1,105 @@
+{
+  "openapi": "3.0.4",
+  "info": {
+    "title": "FluentCRM API",
+    "description": "Complete REST API documentation for FluentCRM — a self-hosted email marketing and CRM plugin for WordPress.",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://{website}/wp-json/fluent-crm/v2",
+      "description": "Your WordPress website",
+      "variables": {
+        "website": {
+          "default": "YourWebsite.com",
+          "description": "Your WordPress website domain (without https://)"
+        }
+      }
+    }
+  ],
+  "security": [
+    {
+      "ApplicationPasswords": []
+    }
+  ],
+  "paths": {
+    "/email-patterns/categories": {
+      "get": {
+        "operationId": "listEmailPatternCategories",
+        "summary": "GET List Email Pattern Categories",
+        "description": "Retrieve the unique category names currently used by saved email patterns. The list is sorted alphabetically.",
+        "tags": [
+          "Email Patterns"
+        ],
+        "security": [
+          {
+            "ApplicationPasswords": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "List of unique email pattern category names.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "categories": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Alphabetically sorted category names."
+                    }
+                  }
+                },
+                "example": {
+                  "categories": [
+                    "Announcements",
+                    "Onboarding",
+                    "Promotions"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Human-readable error message"
+          },
+          "code": {
+            "type": "string",
+            "description": "Error code"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "integer",
+                "description": "HTTP status code"
+              }
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "ApplicationPasswords": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Authorization",
+        "description": "WordPress Application Passwords — use Basic auth with your WordPress username and an application password in the format: username:application_password"
+      }
+    }
+  }
+}

--- a/src/public/openapi/email-patterns/list-email-patterns-wp-format.json
+++ b/src/public/openapi/email-patterns/list-email-patterns-wp-format.json
@@ -1,0 +1,195 @@
+{
+  "openapi": "3.0.4",
+  "info": {
+    "title": "FluentCRM API",
+    "description": "Complete REST API documentation for FluentCRM — a self-hosted email marketing and CRM plugin for WordPress.",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://{website}/wp-json/fluent-crm/v2",
+      "description": "Your WordPress website",
+      "variables": {
+        "website": {
+          "default": "YourWebsite.com",
+          "description": "Your WordPress website domain (without https://)"
+        }
+      }
+    }
+  ],
+  "security": [
+    {
+      "ApplicationPasswords": []
+    }
+  ],
+  "paths": {
+    "/email-patterns/wp-format": {
+      "get": {
+        "operationId": "listEmailPatternsWpFormat",
+        "summary": "GET List Email Patterns (WP Format)",
+        "description": "Retrieve email patterns formatted like WordPress `wp_block` REST responses for the FluentCRM editor middleware.",
+        "tags": [
+          "Email Patterns"
+        ],
+        "security": [
+          {
+            "ApplicationPasswords": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Email patterns in WordPress block REST format.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WpBlockEmailPattern"
+                  }
+                },
+                "example": [
+                  {
+                    "id": 12,
+                    "date": "2026-04-20 09:15:00",
+                    "date_gmt": "2026-04-20 09:15:00",
+                    "modified": "2026-04-21 11:30:00",
+                    "modified_gmt": "2026-04-21 11:30:00",
+                    "slug": "fluentcrm/welcome-pattern-12",
+                    "status": "publish",
+                    "type": "wp_block",
+                    "link": "",
+                    "title": {
+                      "raw": "Welcome Pattern"
+                    },
+                    "content": {
+                      "raw": "<!-- wp:paragraph --><p>Welcome to our newsletter.</p><!-- /wp:paragraph -->",
+                      "protected": false
+                    },
+                    "meta": {},
+                    "wp_pattern_sync_status": "unsynced",
+                    "wp_pattern_category": [
+                      3
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Human-readable error message"
+          },
+          "code": {
+            "type": "string",
+            "description": "Error code"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "integer",
+                "description": "HTTP status code"
+              }
+            }
+          }
+        }
+      },
+      "WpBlockEmailPattern": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Pattern ID."
+          },
+          "date": {
+            "type": "string",
+            "description": "Creation timestamp."
+          },
+          "date_gmt": {
+            "type": "string",
+            "description": "Creation timestamp in GMT."
+          },
+          "modified": {
+            "type": "string",
+            "description": "Last modification timestamp."
+          },
+          "modified_gmt": {
+            "type": "string",
+            "description": "Last modification timestamp in GMT."
+          },
+          "slug": {
+            "type": "string",
+            "description": "Pattern slug."
+          },
+          "status": {
+            "type": "string",
+            "description": "Always `publish` for this response shape."
+          },
+          "type": {
+            "type": "string",
+            "description": "Always `wp_block`."
+          },
+          "link": {
+            "type": "string",
+            "description": "Pattern link. Currently empty."
+          },
+          "title": {
+            "type": "object",
+            "properties": {
+              "raw": {
+                "type": "string",
+                "description": "Raw pattern title."
+              }
+            }
+          },
+          "content": {
+            "type": "object",
+            "properties": {
+              "raw": {
+                "type": "string",
+                "description": "Raw block content."
+              },
+              "protected": {
+                "type": "boolean",
+                "description": "Whether the content is protected."
+              }
+            }
+          },
+          "meta": {
+            "type": "object",
+            "description": "WordPress block metadata object."
+          },
+          "wp_pattern_sync_status": {
+            "type": "string",
+            "description": "Pattern sync status."
+          },
+          "wp_pattern_category": {
+            "type": "array",
+            "description": "Resolved WordPress-style category IDs.",
+            "items": {
+              "type": "integer"
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "ApplicationPasswords": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Authorization",
+        "description": "WordPress Application Passwords — use Basic auth with your WordPress username and an application password in the format: username:application_password"
+      }
+    }
+  }
+}

--- a/src/public/openapi/email-patterns/list-email-patterns.json
+++ b/src/public/openapi/email-patterns/list-email-patterns.json
@@ -1,0 +1,196 @@
+{
+  "openapi": "3.0.4",
+  "info": {
+    "title": "FluentCRM API",
+    "description": "Complete REST API documentation for FluentCRM — a self-hosted email marketing and CRM plugin for WordPress.",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://{website}/wp-json/fluent-crm/v2",
+      "description": "Your WordPress website",
+      "variables": {
+        "website": {
+          "default": "YourWebsite.com",
+          "description": "Your WordPress website domain (without https://)"
+        }
+      }
+    }
+  ],
+  "security": [
+    {
+      "ApplicationPasswords": []
+    }
+  ],
+  "paths": {
+    "/email-patterns": {
+      "get": {
+        "operationId": "listEmailPatterns",
+        "summary": "GET List Email Patterns",
+        "description": "Retrieve paginated reusable email patterns stored in FluentCRM. Supports simple text search against the underlying pattern value payload and returns normalized pattern objects.",
+        "tags": [
+          "Email Patterns"
+        ],
+        "security": [
+          {
+            "ApplicationPasswords": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Search term applied against the stored pattern value payload.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "per_page",
+            "in": "query",
+            "description": "Number of patterns per page.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 15
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number for pagination.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of email patterns.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "patterns": {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/EmailPattern"
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "description": "Total number of patterns matching the query."
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "patterns": {
+                    "data": [
+                      {
+                        "id": 12,
+                        "slug": "fluentcrm/welcome-pattern-12",
+                        "title": "Welcome Pattern",
+                        "content": "<!-- wp:paragraph --><p>Welcome to our newsletter.</p><!-- /wp:paragraph -->",
+                        "category": "Onboarding",
+                        "description": "Reusable onboarding email block.",
+                        "sync_status": "unsynced",
+                        "created_at": "2026-04-20 09:15:00",
+                        "updated_at": "2026-04-21 11:30:00"
+                      }
+                    ],
+                    "total": 1
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Human-readable error message"
+          },
+          "code": {
+            "type": "string",
+            "description": "Error code"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "integer",
+                "description": "HTTP status code"
+              }
+            }
+          }
+        }
+      },
+      "EmailPattern": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Pattern ID."
+          },
+          "slug": {
+            "type": "string",
+            "description": "Generated pattern slug."
+          },
+          "title": {
+            "type": "string",
+            "description": "Pattern title."
+          },
+          "content": {
+            "type": "string",
+            "description": "Pattern content HTML or block markup."
+          },
+          "category": {
+            "type": "string",
+            "description": "Assigned category name."
+          },
+          "description": {
+            "type": "string",
+            "description": "Pattern description."
+          },
+          "sync_status": {
+            "type": "string",
+            "description": "Pattern sync status.",
+            "default": "unsynced"
+          },
+          "created_at": {
+            "type": "string",
+            "description": "Pattern creation timestamp."
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "Pattern update timestamp."
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "ApplicationPasswords": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Authorization",
+        "description": "WordPress Application Passwords — use Basic auth with your WordPress username and an application password in the format: username:application_password"
+      }
+    }
+  }
+}

--- a/src/public/openapi/email-patterns/update-email-pattern.json
+++ b/src/public/openapi/email-patterns/update-email-pattern.json
@@ -1,0 +1,256 @@
+{
+  "openapi": "3.0.4",
+  "info": {
+    "title": "FluentCRM API",
+    "description": "Complete REST API documentation for FluentCRM — a self-hosted email marketing and CRM plugin for WordPress.",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://{website}/wp-json/fluent-crm/v2",
+      "description": "Your WordPress website",
+      "variables": {
+        "website": {
+          "default": "YourWebsite.com",
+          "description": "Your WordPress website domain (without https://)"
+        }
+      }
+    }
+  ],
+  "security": [
+    {
+      "ApplicationPasswords": []
+    }
+  ],
+  "paths": {
+    "/email-patterns/{id}": {
+      "put": {
+        "operationId": "updateEmailPattern",
+        "summary": "PUT Update Email Pattern",
+        "description": "Update an existing reusable email pattern. Supports both the standard pattern fields and the WordPress editor-style fields used by the block editor middleware.",
+        "tags": [
+          "Email Patterns"
+        ],
+        "security": [
+          {
+            "ApplicationPasswords": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The email pattern ID.",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "raw": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    ],
+                    "description": "Updated pattern title. Supports plain string or editor-style `{ raw }` object."
+                  },
+                  "content": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "raw": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    ],
+                    "description": "Updated pattern content. Supports plain string or editor-style `{ raw }` object."
+                  },
+                  "category": {
+                    "type": "string",
+                    "description": "Category name."
+                  },
+                  "wp_pattern_category": {
+                    "type": "array",
+                    "description": "WordPress-style category IDs. When present, overrides the plain `category` field.",
+                    "items": {
+                      "type": "integer"
+                    }
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "Pattern description."
+                  },
+                  "sync_status": {
+                    "type": "string",
+                    "description": "Pattern sync status."
+                  },
+                  "meta": {
+                    "type": "object",
+                    "description": "WordPress editor metadata.",
+                    "properties": {
+                      "wp_pattern_sync_status": {
+                        "type": "string",
+                        "description": "Sync status override from the block editor middleware."
+                      }
+                    }
+                  }
+                }
+              },
+              "example": {
+                "title": "Updated Welcome Pattern",
+                "content": "<!-- wp:paragraph --><p>Updated welcome message.</p><!-- /wp:paragraph -->",
+                "category": "Onboarding",
+                "description": "Updated reusable onboarding block.",
+                "sync_status": "unsynced"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Email pattern updated successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "pattern": {
+                      "$ref": "#/components/schemas/EmailPattern"
+                    }
+                  }
+                },
+                "example": {
+                  "message": "Pattern updated successfully",
+                  "pattern": {
+                    "id": 12,
+                    "slug": "fluentcrm/updated-welcome-pattern-12",
+                    "title": "Updated Welcome Pattern",
+                    "content": "<!-- wp:paragraph --><p>Updated welcome message.</p><!-- /wp:paragraph -->",
+                    "category": "Onboarding",
+                    "description": "Updated reusable onboarding block.",
+                    "sync_status": "unsynced",
+                    "created_at": "2026-04-20 09:15:00",
+                    "updated_at": "2026-04-28 16:05:00"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Email pattern not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "message": "No query results for model"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Human-readable error message"
+          },
+          "code": {
+            "type": "string",
+            "description": "Error code"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "integer",
+                "description": "HTTP status code"
+              }
+            }
+          }
+        }
+      },
+      "EmailPattern": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Pattern ID."
+          },
+          "slug": {
+            "type": "string",
+            "description": "Generated pattern slug."
+          },
+          "title": {
+            "type": "string",
+            "description": "Pattern title."
+          },
+          "content": {
+            "type": "string",
+            "description": "Pattern content HTML or block markup."
+          },
+          "category": {
+            "type": "string",
+            "description": "Assigned category name."
+          },
+          "description": {
+            "type": "string",
+            "description": "Pattern description."
+          },
+          "sync_status": {
+            "type": "string",
+            "description": "Pattern sync status.",
+            "default": "unsynced"
+          },
+          "created_at": {
+            "type": "string",
+            "description": "Pattern creation timestamp."
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "Pattern update timestamp."
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "ApplicationPasswords": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Authorization",
+        "description": "WordPress Application Passwords — use Basic auth with your WordPress username and an application password in the format: username:application_password"
+      }
+    }
+  }
+}

--- a/src/rest-api/index.md
+++ b/src/rest-api/index.md
@@ -1,6 +1,6 @@
 # FluentCRM REST API
 
-Complete REST API documentation for FluentCRM — covering **319 endpoints** across 28 modules, including FluentCampaign Pro.
+Complete REST API documentation for FluentCRM — covering **330 endpoints** across 29 modules, including FluentCampaign Pro.
 
 ## Base URL
 
@@ -52,6 +52,7 @@ Use test/staging sites only. API requests make permanent changes to your data.
 |--------|-----------|-------------|
 | [Campaigns](/rest-api/operations/campaigns/list-campaigns) | 32 | Create, schedule, send, and analyze email campaigns |
 | [Templates](/rest-api/operations/templates/list-templates) | 11 | Email templates, smart codes, global styles |
+| [Email Patterns](/rest-api/operations/email-patterns/list-email-patterns) | 11 | Reusable email patterns and editor blocks |
 | [Sequences](/rest-api/operations/sequences/list-sequences) | 18 | Automated email sequences (Pro) |
 | [Recurring Campaigns](/rest-api/operations/recurring-campaigns/list-recurring-campaigns) | 14 | Recurring/automated campaigns (Pro) |
 

--- a/src/rest-api/operations/email-patterns/bulk-action-email-patterns.md
+++ b/src/rest-api/operations/email-patterns/bulk-action-email-patterns.md
@@ -1,0 +1,7 @@
+---
+title: Bulk Action Email Patterns
+description: "Perform supported bulk actions on email patterns."
+outline: false
+aside: false
+---
+<OAOperation operationId="bulkActionEmailPatterns" specUrl="/openapi/email-patterns/bulk-action-email-patterns.json" />

--- a/src/rest-api/operations/email-patterns/create-email-pattern-category.md
+++ b/src/rest-api/operations/email-patterns/create-email-pattern-category.md
@@ -1,0 +1,7 @@
+---
+title: Create Email Pattern Category
+description: "Create an email pattern category or return an existing matching one."
+outline: false
+aside: false
+---
+<OAOperation operationId="createEmailPatternCategory" specUrl="/openapi/email-patterns/create-email-pattern-category.json" />

--- a/src/rest-api/operations/email-patterns/create-email-pattern-wp-format.md
+++ b/src/rest-api/operations/email-patterns/create-email-pattern-wp-format.md
@@ -1,0 +1,7 @@
+---
+title: Create Email Pattern (WP Format)
+description: "Create an email pattern using WordPress block REST payload format."
+outline: false
+aside: false
+---
+<OAOperation operationId="createEmailPatternWpFormat" specUrl="/openapi/email-patterns/create-email-pattern-wp-format.json" />

--- a/src/rest-api/operations/email-patterns/create-email-pattern.md
+++ b/src/rest-api/operations/email-patterns/create-email-pattern.md
@@ -1,0 +1,7 @@
+---
+title: Create Email Pattern
+description: "Create a reusable email pattern in FluentCRM."
+outline: false
+aside: false
+---
+<OAOperation operationId="createEmailPattern" specUrl="/openapi/email-patterns/create-email-pattern.json" />

--- a/src/rest-api/operations/email-patterns/delete-email-pattern-category.md
+++ b/src/rest-api/operations/email-patterns/delete-email-pattern-category.md
@@ -1,0 +1,7 @@
+---
+title: Delete Email Pattern Category
+description: "Delete an email pattern category by ID."
+outline: false
+aside: false
+---
+<OAOperation operationId="deleteEmailPatternCategory" specUrl="/openapi/email-patterns/delete-email-pattern-category.json" />

--- a/src/rest-api/operations/email-patterns/delete-email-pattern.md
+++ b/src/rest-api/operations/email-patterns/delete-email-pattern.md
@@ -1,0 +1,7 @@
+---
+title: Delete Email Pattern
+description: "Delete a reusable email pattern by ID."
+outline: false
+aside: false
+---
+<OAOperation operationId="deleteEmailPattern" specUrl="/openapi/email-patterns/delete-email-pattern.json" />

--- a/src/rest-api/operations/email-patterns/get-email-pattern.md
+++ b/src/rest-api/operations/email-patterns/get-email-pattern.md
@@ -1,0 +1,7 @@
+---
+title: Get Email Pattern
+description: "Retrieve a single reusable email pattern by ID."
+outline: false
+aside: false
+---
+<OAOperation operationId="getEmailPattern" specUrl="/openapi/email-patterns/get-email-pattern.json" />

--- a/src/rest-api/operations/email-patterns/list-email-pattern-categories.md
+++ b/src/rest-api/operations/email-patterns/list-email-pattern-categories.md
@@ -1,0 +1,7 @@
+---
+title: List Email Pattern Categories
+description: "Retrieve the unique category names used by saved email patterns."
+outline: false
+aside: false
+---
+<OAOperation operationId="listEmailPatternCategories" specUrl="/openapi/email-patterns/list-email-pattern-categories.json" />

--- a/src/rest-api/operations/email-patterns/list-email-patterns-wp-format.md
+++ b/src/rest-api/operations/email-patterns/list-email-patterns-wp-format.md
@@ -1,0 +1,7 @@
+---
+title: List Email Patterns (WP Format)
+description: "Retrieve email patterns in WordPress block REST format."
+outline: false
+aside: false
+---
+<OAOperation operationId="listEmailPatternsWpFormat" specUrl="/openapi/email-patterns/list-email-patterns-wp-format.json" />

--- a/src/rest-api/operations/email-patterns/list-email-patterns.md
+++ b/src/rest-api/operations/email-patterns/list-email-patterns.md
@@ -1,0 +1,7 @@
+---
+title: List Email Patterns
+description: "Retrieve paginated reusable email patterns from FluentCRM."
+outline: false
+aside: false
+---
+<OAOperation operationId="listEmailPatterns" specUrl="/openapi/email-patterns/list-email-patterns.json" />

--- a/src/rest-api/operations/email-patterns/update-email-pattern.md
+++ b/src/rest-api/operations/email-patterns/update-email-pattern.md
@@ -1,0 +1,7 @@
+---
+title: Update Email Pattern
+description: "Update an existing reusable email pattern."
+outline: false
+aside: false
+---
+<OAOperation operationId="updateEmailPattern" specUrl="/openapi/email-patterns/update-email-pattern.json" />


### PR DESCRIPTION
Introduce Email Patterns endpoints and docs. Added OpenAPI JSON specs for list, list (WP format), list categories, create (standard & WP format), create category, get, update, delete, delete category, and bulk-action. Added corresponding REST operation markdown files and updated the REST API sidebar to include the new Email Patterns section and links. Also updated rest-api/index.md to reference the new docs.